### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 TPObfuscatedString
 ==================
 
-[![Cocoapods Compatible](https://img.shields.io/cocoapods/v/TPObfuscatedString.svg)](https://img.shields.io/cocoapods/v/TPObfuscatedString.svg)
+[![CocoaPods Compatible](https://img.shields.io/cocoapods/v/TPObfuscatedString.svg)](https://img.shields.io/cocoapods/v/TPObfuscatedString.svg)
 [![Language](https://img.shields.io/badge/language-Swift-orange.svg)](https://developer.apple.com/swift/)
 [![Platform](https://img.shields.io/cocoapods/p/TPObfuscatedString.svg?style=flat)](http://cocoadocs.org/docsets/TPObfuscatedString.svg)
 [![License](https://img.shields.io/badge/license-MIT-lightgrey.svg)](https://github.com/Techprimate/TPLocalizedError/blob/master/LICENSE)


### PR DESCRIPTION
This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>

<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>


Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
